### PR TITLE
Updated Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Refer https://github.com/cielavenir/p7zip/blob/main/.github/workflows/ci.yaml fo
 This is the place for 7zz (Well known as 7zip-21.02 Linux version) to include major modern codecs such as Brotli, Fast LZMA2, LZ4, LZ5, Lizard and Zstd. In order to support multithreading for those addional codecs, this project depends on the [Multithreading Library](https://github.com/mcmilk/zstdmt).
 
 ## Codec overview
-1. [Zstandard] v1.5.0 is a real-time compression algorithm, providing high compression ratios. It offers a very wide range of compression / speed trade-off, while being backed by a very fast decoder.
+1. [Zstandard] v1.5.2 is a real-time compression algorithm, providing high compression ratios. It offers a very wide range of compression / speed trade-off, while being backed by a very fast decoder.
    - Levels: 1..22
 
 2. [LZ4] v1.9.3 is lossless compression algorithm, providing compression speed at 400 MB/s per core (0.16 Bytes/cycle). It features an extremely fast decoder, with speed in multiple GB/s per core (0.71 Bytes/cycle). A high compression derivative, called LZ4_HC, is available, trading customizable CPU time for compression ratio.

--- a/README.md
+++ b/README.md
@@ -179,9 +179,9 @@ Hashers:
 
 ## Version Information
 
-- 7zz Version 21.02 alpha
+- 7zz Version 21.07
   - [LZ4] Version 1.9.3
-  - [Zstandard] Version 1.5.0
+  - [Zstandard] Version 1.5.2
   - [Fast LZMA2] Version v1.0.1
   - [Brotli] Version v1.0.9
   - [LZ5] Version v1.5


### PR DESCRIPTION
Zstandard v1.5.2 is used in the latest release.